### PR TITLE
Set surrogate key header

### DIFF
--- a/apollos-church-api/src/server.js
+++ b/apollos-church-api/src/server.js
@@ -91,6 +91,9 @@ app.get('/version', cors(), (req, res) => {
 });
 
 app.use((req, res, next) => {
+  // Set a constant surrogate key for soft purging
+  res.setHeader('Surrogate-Key', 'all');
+
   const prevSetHeader = res.setHeader;
   res.setHeader = (...args) => {
     let [name, value] = args;


### PR DESCRIPTION

> Purge-all requests cannot be done in soft mode and will always immediately invalidate all cached content associated with the service. To do a soft-purge-all, consider applying a constant surrogate key tag (e.g., "all") to all objects.