### PR TITLE
34 personal details

### DIFF
--- a/apollos-church-api/src/data/rockWithPostgres.js
+++ b/apollos-church-api/src/data/rockWithPostgres.js
@@ -15,6 +15,13 @@ class personDataSource extends postgresPerson.dataSource {
     });
     return rockPersonId;
   }
+
+  async getFromId(id, encodedId, { originType = null } = {}) {
+    const person = await super.getFromId(id, encodedId, { originType });
+    // fixes Error: Expected a value of type "GENDER" but received: ""
+    person.gender = person.gender || 'Unknown';
+    return person;
+  }
 }
 
 // These resolvers make sure that calls to updating profile fields update both the

--- a/apolloschurchapp/src/user-settings/PersonalDetails.js
+++ b/apolloschurchapp/src/user-settings/PersonalDetails.js
@@ -95,8 +95,12 @@ class PersonalDetails extends PureComponent {
   render() {
     return (
       <Query query={GET_USER_PROFILE} fetchPolicy="cache-and-network">
-        {({ data: { currentUser = { profile: {} } } = {} }) => {
-          const { firstName, lastName, email } = currentUser.profile;
+        {({ data, loading }) => {
+          const currentUser = data?.currentUser || {};
+          const { firstName, lastName, email } = currentUser.profile || {};
+          if (loading) {
+            return null;
+          }
 
           return (
             <Mutation
@@ -121,6 +125,7 @@ class PersonalDetails extends PureComponent {
               {(updateDetails) => (
                 <Formik
                   initialValues={{ firstName, lastName, email }}
+                  enableReinitialize
                   validationSchema={Yup.object().shape({
                     firstName: Yup.string().required('First Name is required!'),
                     lastName: Yup.string().required('Last Name is required!'),


### PR DESCRIPTION
* Waits to load the form until the profile query has completed.  The form was initially loading empty values b/c the query was still loading, and then didn't reinitialize the initial values after the query completed.
* Fixes an issue where a new user having an null gender causes a GraphQL error

fixes #34